### PR TITLE
Separate unencrypted header migration from key-spec migration.

### DIFF
--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
@@ -8,11 +8,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern const NSUInteger kSqliteHeaderLength;
 extern const NSUInteger kSQLCipherSaltLength;
-extern const NSUInteger kSQLCipherDerivedKeyLength;
+extern const NSUInteger kSQLCipherKeyLength;
 extern const NSUInteger kSQLCipherKeySpecLength;
 
 typedef void (^YapDatabaseSaltBlock)(NSData *saltData);
-typedef void (^YapDatabaseKeySpecBlock)(NSData *keySpecData);
 
 // This class contains utility methods for use with SQLCipher encrypted
 // databases, specifically to address an issue around database files that
@@ -98,7 +97,7 @@ typedef void (^YapDatabaseKeySpecBlock)(NSData *keySpecData);
 // * This method should always be pretty fast, and should be safe to
 //   call from within [UIApplicationDelegate application: didFinishLaunchingWithOptions:].
 // * If convertDatabaseIfNecessary converts the database, it will use its
-//   saltBlock and keySpecBlock parameters to inform you of the salt
+//   recordSaltBlock to inform you of the salt
 //   and keyspec for this database.  These values will be needed when
 //   opening the database, so they should presumably be stored in the
 //   keychain (like the database password).
@@ -129,23 +128,21 @@ typedef void (^YapDatabaseKeySpecBlock)(NSData *keySpecData);
 // * This method will have no effect if the YapDatabase has already been converted.
 // * This method should always be pretty fast, and should be safe to
 //   call from within [UIApplicationDelegate application: didFinishLaunchingWithOptions:].
-// * If convertDatabaseIfNecessary converts the database, it will use its
-//   saltBlock and keySpecBlock parameters to inform you of the salt
-//   and keyspec for this database.  These values will be needed when
-//   opening the database, so they should presumably be stored in the
-//   keychain (like the database password).
+// * IMPORTANT: If you fail to record the salt during conversion you will not be able to decrypt
+//   the database in the future, effectively losing all data.  If convertDatabaseIfNecessary
+//   converts the database, it will use its recordSaltBlock parameter to inform you of the salt
+//   for this database. Within that block you must store the salt somewhere durable.
 + (nullable NSError *)convertDatabaseIfNecessary:(NSString *)databaseFilePath
                                 databasePassword:(NSData *)databasePassword
-                                       saltBlock:(YapDatabaseSaltBlock)saltBlock
-                                    keySpecBlock:(YapDatabaseKeySpecBlock)keySpecBlock;
+                                 recordSaltBlock:(YapDatabaseSaltBlock)recordSaltBlock;
 
 // This method can be used to derive a SQLCipher "key spec" from a
 // database password and salt.  Key spec derivation is somewhat costly.
 // The key spec is needed every time the database file is opened
-// (including every time YapDatabse makes a new database connection),
+// (including every time YapDatabase makes a new database connection),
 // So it benefits performance to pass a pre-derived key spec to
 // YapDatabase.
-+ (nullable NSData *)databaseKeySpecForPassword:(NSData *)passwordData saltData:(NSData *)saltData;
++ (nullable NSData *)deriveDatabaseKeySpecForPassword:(NSData *)passwordData saltData:(NSData *)saltData;
 
 #pragma mark - Utils
 

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern const NSUInteger kSqliteHeaderLength;
 extern const NSUInteger kSQLCipherSaltLength;
-extern const NSUInteger kSQLCipherKeyLength;
+extern const NSUInteger kSQLCipherDerivedKeyLength;
 extern const NSUInteger kSQLCipherKeySpecLength;
 
 typedef void (^YapDatabaseSaltBlock)(NSData *saltData);

--- a/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
+++ b/YapDatabase/Utilities/YapDatabaseCryptoUtils.m
@@ -92,7 +92,7 @@ NSCAssert(0, message);                                                          
 
 const NSUInteger kSqliteHeaderLength = 32;
 const NSUInteger kSQLCipherSaltLength = 16;
-const NSUInteger kSQLCipherKeyLength = 32;
+const NSUInteger kSQLCipherDerivedKeyLength = 32;
 const NSUInteger kSQLCipherKeySpecLength = 48;
 
 NSString *const YapDatabaseErrorDomain = @"YapDatabaseErrorDomain";
@@ -169,7 +169,7 @@ NSError *YDBErrorWithDescription(NSString *description)
 
     return [self convertDatabase:databaseFilePath
                 databasePassword:databasePassword
-                       recordSaltBlock:recordSaltBlock];
+                 recordSaltBlock:recordSaltBlock];
 }
 
 + (nullable NSError *)convertDatabase:(NSString *)databaseFilePath
@@ -411,7 +411,7 @@ NSError *YDBErrorWithDescription(NSString *description)
     YapAssert(passwordData.length > 0);
     YapAssert(saltData.length == kSQLCipherSaltLength);
 
-    NSMutableData *_Nullable derivedKeyData = [NSMutableData dataWithLength:kSQLCipherKeyLength];
+    NSMutableData *_Nullable derivedKeyData = [NSMutableData dataWithLength:kSQLCipherDerivedKeyLength];
     if (!derivedKeyData) {
         YapFail(@"failed to allocate derivedKeyData");
         return nil;
@@ -444,7 +444,7 @@ NSError *YDBErrorWithDescription(NSString *description)
     YapAssert(saltData.length == kSQLCipherSaltLength);
 
     NSData *_Nullable derivedKeyData = [self deriveDatabaseKeyForPassword:passwordData saltData:saltData];
-    if (!derivedKeyData || derivedKeyData.length != kSQLCipherKeyLength) {
+    if (!derivedKeyData || derivedKeyData.length != kSQLCipherDerivedKeyLength) {
         YDBLogError(@"Error deriving key");
         return nil;
     }

--- a/YapDatabase/YapDatabase.m
+++ b/YapDatabase/YapDatabase.m
@@ -825,8 +825,7 @@ static int connectionBusyHandler(void *ptr, int count) {
         if (options.cipherKeySpecBlock)
         {
             // Do nothing.
-        } else if (!options.cipherKeyBlock ||
-                   options.cipherSaltBlock) {
+        } else if (!(options.cipherKeyBlock && options.cipherSaltBlock)) {
             NSAssert(NO, @"If you're using YapDatabaseOptions.cipherUnencryptedHeaderLength, you need to set either cipherKeySpecBlock or both cipherKeyBlock and cipherSaltBlock.");
             return NO;
         }


### PR DESCRIPTION
Using an unencrypted header and using a raw-key spec are two separate concerns. 

Since we intend to upstream this code, we should separate them so other users can pick/choose which if either of those features they want to use.

PTAL @charlesmchen 