### PR TITLE
smaller autorelease pools

### DIFF
--- a/YapDatabase/YapDatabaseTransaction.m
+++ b/YapDatabase/YapDatabaseTransaction.m
@@ -26,7 +26,7 @@
 #pragma unused(ydbLogLevel)
 
 typedef BOOL (^YapBoolBlock)(void);
-const NSUInteger kDefaultBatchSize = 10 * 1000;
+const NSUInteger kDefaultBatchSize = 1000;
 
 @implementation YapDatabaseReadTransaction
 


### PR DESCRIPTION
On my pretty old device memory was getting pretty out of hand without 10k batch size.

For a *very* large install, 100k messages, I don't think doing 100 autorelease pools is excessive, and substantially helps the memory footprint.



